### PR TITLE
logging,  prechecks. 

### DIFF
--- a/bootstrap/boot.py
+++ b/bootstrap/boot.py
@@ -1,3 +1,4 @@
+from bootstrap import log
 from bootstrap.utils import cmds, mkdirs, packages, prereq_packages, softlinks
 
 
@@ -33,9 +34,9 @@ def boot(cfg: dict, name, systype, loctype, extra_cfg: dict = None):
     """
     Run the main config, then optionally run an extra config (e.g., work or private specific).
     """
-    print("=== Processing main config ===")
+    log.header("Processing main config")
     boot_config(cfg, systype, loctype, run_prereqs=True)
 
     if extra_cfg:
-        print(f"\n=== Processing extra config for {loctype} ===")
+        log.header(f"Processing extra config for {loctype}")
         boot_config(extra_cfg, systype, loctype, run_prereqs=False)

--- a/bootstrap/log.py
+++ b/bootstrap/log.py
@@ -1,0 +1,33 @@
+import click
+from datetime import datetime
+
+
+def _ts():
+    return datetime.now().strftime("%H:%M:%S")
+
+
+def header(msg):
+    ts = _ts()
+    click.echo(click.style(f"\n{'=' * 60}", fg="cyan", bold=True))
+    click.echo(click.style(f"  [{ts}] {msg}", fg="cyan", bold=True))
+    click.echo(click.style(f"{'=' * 60}", fg="cyan", bold=True))
+
+
+def info(msg):
+    click.echo(click.style(f"  [{_ts()}] [INFO] {msg}", fg="green"))
+
+
+def cmd(msg):
+    click.echo(click.style(f"  [{_ts()}] [CMD]  {msg}", fg="yellow"))
+
+
+def action(msg):
+    click.echo(click.style(f"  [{_ts()}] [ACT]  {msg}", fg="blue"))
+
+
+def skip(msg):
+    click.echo(click.style(f"  [{_ts()}] [SKIP] {msg}", dim=True))
+
+
+def error(msg):
+    click.echo(click.style(f"  [{_ts()}] [FAIL] {msg}", fg="red", bold=True))

--- a/bootstrap/runboot.py
+++ b/bootstrap/runboot.py
@@ -1,11 +1,34 @@
 import json
 import os
+import sys
 
 import click
 
-from bootstrap import utils
+from bootstrap import log, utils
 from bootstrap.boot import boot
 from bootstrap.schema import config_validate
+
+def detect_systype():
+    """Auto-detect the system type from the current platform."""
+    if sys.platform == "darwin":
+        return "mac"
+    if sys.platform == "linux":
+        try:
+            with open("/etc/os-release") as f:
+                for line in f:
+                    if line.startswith("ID="):
+                        distro_id = line.strip().split("=", 1)[1].strip('"')
+                        if distro_id == "arch":
+                            return "arch"
+                        if distro_id == "ubuntu":
+                            return "ubuntu"
+        except FileNotFoundError:
+            pass
+    raise RuntimeError(
+        f"Could not auto-detect systype (platform={sys.platform!r}). "
+        "Please specify --systype explicitly."
+    )
+
 
 def load_config(path):
     """Load and validate a config file, returns None if file doesn't exist."""
@@ -19,9 +42,14 @@ def load_config(path):
 
 
 @click.command()
-@click.option("--systype", prompt="enter [mac] or [arch] or [ubuntu]", help="what system?")
+@click.option("--systype", default=None, help="System type: mac, arch, or ubuntu (auto-detected if omitted)")
 @click.option("--loctype", prompt="enter [work] or [private]", help="use work or private dotfiles?")
 def main(systype, loctype):
+    if systype is None:
+        systype = detect_systype()
+        log.info(f"Auto-detected systype: {systype}")
+    else:
+        log.info(f"Using specified systype: {systype}")
     assert systype in ["mac", "arch", "ubuntu"]
     assert loctype in ["work", "private"]
     name = os.environ.get("USER")
@@ -35,9 +63,9 @@ def main(systype, loctype):
     extra_config_path = f"~/dotfiles/bootstrap_config_{loctype}.json"
     extra_cfg = load_config(extra_config_path)
     if extra_cfg:
-        print(f"Found extra config: {extra_config_path}")
+        log.info(f"Found extra config: {extra_config_path}")
     else:
-        print(f"No extra config found at {extra_config_path}, skipping")
+        log.skip(f"No extra config found at {extra_config_path}")
 
     # go!
     boot(cfg, name, systype, loctype, extra_cfg)

--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -30,13 +30,13 @@ schema = {
             },
         },
         "commands": {
-            "description": "a list of arbitrary commands to run, which can be specified as os-agnostic, or by OS type. Warning, whatever you put here will be executed!.",
+            "description": "a list of arbitrary commands to run, which can be specified as os-agnostic, or by OS type. Warning, whatever you put here will be executed!. Each entry can be a plain string or an object with cmd, check, and label fields.",
             "type": "object",
             "properties": {
-                "all": {"type": "array", "items": {"type": "string"}},
-                "mac": {"type": "array", "items": {"type": "string"}},
-                "arch": {"type": "array", "items": {"type": "string"}},
-                "ubuntu": {"type": "array", "items": {"type": "string"}},
+                "all": {"type": "array", "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]}},
+                "mac": {"type": "array", "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]}},
+                "arch": {"type": "array", "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]}},
+                "ubuntu": {"type": "array", "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]}},
             },
         },
         "packages": {
@@ -79,6 +79,16 @@ schema = {
                 "src": {"type": "string"},
                 "dst": {"type": "string"},
             },
+        },
+        "command_with_check": {
+            "type": "object",
+            "required": ["cmd"],
+            "properties": {
+                "cmd": {"type": "string", "description": "The command to run."},
+                "check": {"type": "string", "description": "Shell command — if exit 0, skip cmd."},
+                "label": {"type": "string", "description": "Human-readable name for logs (defaults to truncated cmd)."},
+            },
+            "additionalProperties": False,
         },
     },
     "additionalProperties": False,

--- a/bootstrap/utils.py
+++ b/bootstrap/utils.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 import sys
 
+from bootstrap import log
+
 HOMEDIR = os.environ.get("HOME")
 SHELLPATH = os.environ.get("SHELL")
 
@@ -39,13 +41,10 @@ def _run_cmd(args, cwd=None, shortcircuit=True):
     if cwd:
         cwd = _replace_home(cwd)
 
-    print(
-        "\nRunning: {0} {1}".format(
-            " ".join(args) if isinstance(args, list) else args,
-            "from: {}".format(cwd) if cwd else "",
-        ),
-        flush=True,
-    )
+    log.cmd("{0} {1}".format(
+        " ".join(args) if isinstance(args, list) else args,
+        "from: {}".format(cwd) if cwd else "",
+    ))
 
     # does anybody actually understand how subprocess works?  ¯\_(ツ)_/¯
     proc = subprocess.Popen(
@@ -61,11 +60,11 @@ def _run_cmd(args, cwd=None, shortcircuit=True):
     out, err = proc.communicate()
     status = proc.returncode
     if status != 0:
-        print("FAILED!", flush=True)
+        log.error("FAILED!")
         opt = "out: {0}, err: {1}".format(out, err)
-        print("Status: {0}, Output: {1}\n\n".format(status, opt))
+        log.error("Status: {0}, Output: {1}".format(status, opt))
         if shortcircuit:
-            print("Aborting due to short circuit flag, and a failure!")
+            log.error("Aborting due to short circuit flag, and a failure!")
             sys.exit(1)
 
 
@@ -73,7 +72,7 @@ def _mkdirrec(dest, delete_first=False):
     """recurisvely make a directory"""
     dest = _replace_home(dest)
     if delete_first and os.path.isdir(dest):
-        print("Remove flag is ON, and destination exists, deleting!")
+        log.action("Remove flag is ON, and destination exists, deleting!")
         shutil.rmtree(dest)
     _run_cmd("mkdir -p  " + dest)
     assert os.path.isdir(dest)
@@ -83,7 +82,7 @@ def _softlink(src, dest, cwd=None):
     """remove dest, then softline src to dest"""
     src = _replace_home(src)
     dest = _replace_home(dest)
-    print("linking {0} to {1}".format(src, dest))
+    log.action("linking {0} to {1}".format(src, dest))
     _run_cmd("ln -f -s " + src + " " + dest, cwd)
     assert os.path.exists(dest)
 
@@ -101,7 +100,7 @@ def _gitclone(repo, dest):
 def mkdirs(config, section):
     """recursively make needed dirs for a given section (all, mac, arch, ubuntu)"""
     if "initial_mkdirs" not in config or section not in config["initial_mkdirs"]:
-        print(f"No initial_mkdirs for section {section} in config, skipping")
+        log.skip(f"No initial_mkdirs for section {section} in config")
         return
     for d in config["initial_mkdirs"][section]:
         _mkdirrec(d["dir"], delete_first=d["delfirst"] if "delfirst" in d else False)
@@ -110,20 +109,45 @@ def mkdirs(config, section):
 def softlinks(config, section):
     """make all softlinks"""
     if "links" not in config or section not in config["links"]:
-        print(f"No links for section {section} in config, skipping")
+        log.skip(f"No links for section {section} in config")
         return
     for link in config["links"][section]:
         _softlink(link["src"], link["dst"])
 
 
+def _run_check(check_cmd):
+    """Run a precheck command. Returns True if check passes (exit 0)."""
+    try:
+        result = subprocess.run(
+            check_cmd,
+            shell=True,
+            executable=SHELLPATH,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+
+
 def cmds(config, systype):
     """run all commands"""
     if "commands" not in config:
-        print("No commands in config, skipping")
+        log.skip("No commands in config")
         return
     if systype in config["commands"]:
         for c in config["commands"][systype]:
-            _run_cmd(c)
+            if isinstance(c, str):
+                _run_cmd(c)
+            else:
+                label = c.get("label") or c["cmd"][:60]
+                if "check" in c:
+                    log.info(f"Precheck for: {label}")
+                    if _run_check(c["check"]):
+                        log.skip(f"Precheck passed, skipping: {label}")
+                        continue
+                _run_cmd(c["cmd"])
 
 
 def _install_packages(inner, label):
@@ -136,9 +160,9 @@ def _install_packages(inner, label):
     ptypes_to_process = [p for p in ALL_KNOWN_PACKAGE_TYPES if p in inner]
     # Add any unknown types at the end (future-proofing)
     ptypes_to_process += [p for p in inner if p not in ALL_KNOWN_PACKAGE_TYPES]
-    print(f"Sections to process: {ptypes_to_process} for {label}")
+    log.info(f"Sections to process: {ptypes_to_process} for {label}")
     for ptype in ptypes_to_process:
-        print(f"Processing {ptype}")
+        log.info(f"Processing {ptype}")
         match ptype:
             case "brew_tap":
                 for tap in inner["brew_tap"]:
@@ -182,15 +206,15 @@ def _install_packages(inner, label):
 def prereq_packages(config, systype):
     """install prerequisite packages (rust/cargo, go, poetry) for a given systype"""
     if "prereq_packages" not in config or systype not in config["prereq_packages"]:
-        print(f"No prereq_packages defined for systype {systype}, skipping")
+        log.skip(f"No prereq_packages defined for systype {systype}")
         return
-    print(f"\n=== Installing prerequisite packages for {systype} ===")
+    log.header(f"Installing prerequisite packages for {systype}")
     _install_packages(config["prereq_packages"][systype], f"prereq {systype}")
 
 
 def packages(config, systype):
     """install all packages for a given systype (mac/arch/ubuntu/all)"""
     if "packages" not in config or systype not in config["packages"]:
-        print(f"No packages defined for systype {systype}, skipping")
+        log.skip(f"No packages defined for systype {systype}")
         return
     _install_packages(config["packages"][systype], f"systype {systype}")

--- a/sample_config.json
+++ b/sample_config.json
@@ -13,7 +13,11 @@
             "sudo apt-get install npm",
             "sudo npm install -g n",
             "sudo n stable",
-            "rm -rf ~/.pyenv/; curl https://pyenv.run | bash",
+            {
+                "cmd": "rm -rf ~/.pyenv/; curl https://pyenv.run | bash",
+                "check": "test -d ~/.pyenv && ~/.pyenv/bin/pyenv --version",
+                "label": "Install pyenv"
+            },
             "curl \"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip\" -o \"awscliv2.zip\"; unzip awscliv2.zip; sudo ./aws/install",
             "sudo snap install diff-so-fancy"
         ]


### PR DESCRIPTION
- Introduce a log module with [HH:MM:SS] timestamps on all output, replace raw print() calls throughout with structured log levels (INFO, CMD, ACT, SKIP, FAIL). 
- Add command precheck support: commands in config can now be objects with cmd, check, and label fields — if the check command exits 0 the command is skipped, avoiding slow idempotent re-runs. Schema updated to accept both plain strings and command_with_check objects. 
- adds auto-detection of systype from platform.