### PR TITLE
Add windows support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-09
+
+Windows support and the cross-platform refactors needed to make it land cleanly.
+
+### Cross-platform
+- replace shell `mkdir -p` and `ln -f -n -s` with Python primitives (`os.makedirs`, `os.symlink`); drops bash dependency for these ops on every platform
+- HOMEDIR via `os.path.expanduser("~")` so Windows works without `$HOME`
+- `_softlink` refuses to clobber a real directory at dest (safer than `ln -n`'s platform-dependent behavior) and handles broken symlinks via `os.path.lexists`
+
+### Windows-specific
+- new `winget`, `scoop`, `scoop_bucket` package types; `windows` systype auto-detected from `sys.platform`
+- `winget list --id X` precheck so already-installed packages don't get logged as failures (winget exits non-zero with "no upgrade available")
+- scoop installs run one package at a time with `shortcircuit=False`, so a single missing manifest doesn't abort the batch
+- `_run_check` refreshes PATH from HKLM/HKCU registry before each precheck — a chain of skipped prechecks no longer leaves `os.environ` blind to packages installed in a prior bootstrap run
+- Windows-specific helpers live in their own `bootstrap/windows.py`: `refresh_path`, `install_winget_packages`, `set_file_assoc`, `install_file_associations`
+
+### Package types (cross-platform additions)
+- new `pip` package type — `python3 -m pip install --user` on POSIX (PEP 668 / system-Python protections), `python -m pip install` on Windows (winget Python's Scripts dir is on PATH; the `--user` dir is not)
+- `npm` on Windows skips `sudo` (Windows npm installs to a user-writable prefix and there is no `sudo`)
+
+### File associations (Windows)
+- new `file_associations` config section: per-user registration under `HKCU\Software\Classes` (no admin) with optional `name` (FriendlyAppName) and `icon` (DefaultIcon)
+- preserves a user's "Always use this app" selection across re-runs — only clears UserChoice when it points to a different ProgID
+
+### CLI
+- **breaking**: remove `--systype`. Systype is always auto-detected from `sys.platform` and `/etc/os-release`. Pass nothing; if detection fails, runboot raises with the platform name so you can wire up support
+
+### Other
+- schema and README updated for `windows` section, `file_associations`, `pip`, `prereq_packages`
+- `sample_config.json` rewritten — was using the pre-Windows schema and failed validation
+- remove dead `_gitclone()` helper
+
 ## [1.1.0] - 2022-08-30
 - start this changelog
 - convert to poetry

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Summary
-This "package" allows you to specify a complete dev env setup, including packages to install (homebrew, yay, pacman, npm, etc etc).
+This "package" allows you to specify a complete dev env setup, including packages to install (homebrew, yay, pacman, winget, scoop, npm, etc etc).
 You write a `config.json`, then run a python CLI tool.
-I use this to keep multiple machines (work mac, home Arch, Docker based arch dev boxes) all up to date with my dev environment.
+I use this to keep multiple machines (work mac, home Arch, Docker based arch dev boxes, Windows boxes) all up to date with my dev environment.
 
 # Isn't there stuff already like this?
 There are probably many. However, the well known ones; Puppet, Chef, Ansible, etc, are very heavyweight for my needs.
@@ -14,10 +14,11 @@ I am planning on making this more extensible so the user can provide functions t
 
 # Prerequisites
 1. python3 (I am using 3.11) and `poetry`
-2. if on mac, `homebrew`, and if on Arch, `yay`
+2. if on mac, `homebrew`; if on Arch, `yay`; if on Windows, `winget` (ships with Windows 11) and/or `scoop`
 3. If on mac, XCode command line tools (can't even build `gcc` from `homebrew` without this): `sudo xcode-select --install`
-4. make a directory called `~/dotfiles/` with all of your dotfiles. I personally have a private github `dotfiles` repo. I simply clone that to use this.
-5. Write `config.json`; see the next section
+4. If on Windows, enable Developer Mode (Settings → System → For developers → Developer Mode). This lets `os.symlink` work without admin.
+5. make a directory called `dotfiles/` in your home directory with all of your dotfiles. I personally have a private github `dotfiles` repo that I clone there.
+6. Write `config.json`; see the next section
 
 # Config.json
 To use this package, you write a `config.json` to describe what you would like linked, installed, ran, etc.
@@ -37,17 +38,20 @@ These are the major sections:
 5. `packages`: a list of packages to install, which can be specified as os-agnostic, or by OS type. You can also include "agnostic" installs in the os-specific sections, for example, "I only want this NPM package installed on my mac".
 
 Supported package managers:
-- `brew` / `brew_tap`: macOS Homebrew packages and taps
+- `brew` / `brew_tap` / `brew_cask`: macOS Homebrew packages, taps, and casks
 - `pacman` / `yay`: Arch Linux packages
 - `ppa` / `apt` / `snap`: Ubuntu PPAs, apt packages, and snap packages
-- `npm`: Node.js packages (cross-platform)
+- `winget` / `scoop` / `scoop_bucket`: Windows packages via winget and scoop (with bucket support)
+- `npm`: Node.js packages (cross-platform; runs `sudo npm` on POSIX, plain `npm` on Windows)
+- `pip`: Python packages — `python3 -m pip install --user` on POSIX (PEP 668 / system-Python protections), `python -m pip install` on Windows (winget Python is per-user; its Scripts dir is on PATH whereas the `--user` Scripts dir is not)
 - `go_install`: Go packages via `go install` (cross-platform)
 - `cargo`: Rust packages via `cargo install` (cross-platform)
 - `fisher`: Fish shell plugins (cross-platform)
 
-Note: For Ubuntu, `ppa` entries are automatically processed before `apt` regardless of order in the config.
+Note: For Ubuntu, `ppa` entries are automatically processed before `apt` regardless of order in the config. Similarly on Windows, `scoop_bucket` is processed before `scoop` so buckets are available when packages install.
 
 6. `prereq_packages`: packages that provide language toolchains (rust/cargo, go, poetry) needed before other packages can be installed. These are installed before `packages`. Structure is the same as `packages` but keyed by OS only (no `all` section).
+7. `file_associations` (Windows-only): per-user Windows file extension → app launcher. Each entry has `ext` (`.yaml`), `progid` (`Neovim.YAML`), and `cmd` (`wt -- nvim "%1"`). Writes `HKCU\Software\Classes` so no admin is needed; also clears `UserChoice` so Explorer double-click respects your mapping. Runs after `packages` so the target apps exist.
 
 ## Environment-Specific Configs
 
@@ -60,23 +64,19 @@ The extra config files are optional and use the same schema. They're processed a
 
 # Prerequisites
 
-1. You must have `homebrew` installed on mac, and `yay` installed on Arch linux.
-2. You must have `~/dotfiles/` directory with your dotfiles in it.
-3. You must have `config.json` file written.
-4. You must have `python3` and `poetry` installed.
+1. You must have `homebrew` installed on mac, `yay` installed on Arch linux, and `winget`/`scoop` on Windows.
+2. On Windows: enable Developer Mode (Settings → System → For developers) so symlinks work without admin.
+3. You must have `~/dotfiles/` directory with your dotfiles in it.
+4. You must have `config.json` file written.
+5. You must have `python3` and `poetry` installed.
 
 # Install and Running
 
     poetry install
-    poetry run runboot [args]
+    poetry run runboot --loctype work     # work machines
+    poetry run runboot --loctype private  # personal machines
 
-You can also set CMD args on the command line:
-
-    poetry run runboot --systype mac --loctype work
-    poetry run runboot --systype arch --loctype private
-    poetry run runboot --systype ubuntu --loctype work
-
-The script is idempotent - it is safe to run repeatedly. You can add packages to `config.json` and re-run.
+The systype (mac, arch, ubuntu, windows) is detected from `sys.platform` and `/etc/os-release`. The script is idempotent — safe to run repeatedly. Add packages to `config.json` and re-run.
 
 # Major TODOs:
 

--- a/bootstrap/boot.py
+++ b/bootstrap/boot.py
@@ -1,20 +1,22 @@
 from bootstrap import log
 from bootstrap.utils import cmds, mkdirs, packages, prereq_packages, softlinks
+from bootstrap.windows import install_file_associations
 
 
 def boot_config(cfg: dict, systype, loctype, run_prereqs=False):
     """
     Process a single config file.
     CURRENT ORDER (TODO, make this specifiable??)
-    1. generic mkdirs (initial_mkdirs.all)
-    2. os-specific mkdirs (initial_mkdirs.mac/arch/ubuntu)
-    3. generic softlinks (links.all)
-    4. os-specific softlinks (links.mac/arch/ubuntu)
-    5. generic commands
-    6. system specific commands
-    7. prereq packages (rust/cargo, go, poetry) - only on first config
-    8. system specific packages (installs npm, go, etc via pacman/brew/apt)
-    9. generic packages (uses npm, go_install, cargo, fisher)
+     1. generic mkdirs (initial_mkdirs.all)
+     2. os-specific mkdirs (initial_mkdirs.mac/arch/ubuntu/windows)
+     3. generic softlinks (links.all)
+     4. os-specific softlinks (links.mac/arch/ubuntu/windows)
+     5. generic commands
+     6. system specific commands
+     7. prereq packages (rust/cargo, go, poetry) - only on first config
+     8. system specific packages (installs npm, go, etc via pacman/brew/apt/winget)
+     9. generic packages (uses pip, npm, go_install, cargo, fisher)
+    10. file associations (windows-only, runs after packages so target apps exist)
     """
     mkdirs(cfg, "all")
     mkdirs(cfg, systype)
@@ -28,6 +30,7 @@ def boot_config(cfg: dict, systype, loctype, run_prereqs=False):
     # then "all" packages (uses npm, go_install, etc)
     packages(cfg, systype)
     packages(cfg, "all")
+    install_file_associations(cfg)
 
 
 def boot(cfg: dict, name, systype, loctype, extra_cfg: dict = None):

--- a/bootstrap/runboot.py
+++ b/bootstrap/runboot.py
@@ -13,6 +13,8 @@ def detect_systype():
     """Auto-detect the system type from the current platform."""
     if sys.platform == "darwin":
         return "mac"
+    if sys.platform == "win32":
+        return "windows"
     if sys.platform == "linux":
         try:
             with open("/etc/os-release") as f:
@@ -42,15 +44,10 @@ def load_config(path):
 
 
 @click.command()
-@click.option("--systype", default=None, help="System type: mac, arch, or ubuntu (auto-detected if omitted)")
 @click.option("--loctype", prompt="enter [work] or [private]", help="use work or private dotfiles?")
-def main(systype, loctype):
-    if systype is None:
-        systype = detect_systype()
-        log.info(f"Auto-detected systype: {systype}")
-    else:
-        log.info(f"Using specified systype: {systype}")
-    assert systype in ["mac", "arch", "ubuntu"]
+def main(loctype):
+    systype = detect_systype()
+    log.info(f"Detected systype: {systype}")
     assert loctype in ["work", "private"]
     name = os.environ.get("USER")
 

--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -10,23 +10,25 @@ schema = {
             "items": {"type": "string"},
         },
         "initial_mkdirs": {
-            "description": "directories to be recursively made, organized by OS type. Use 'all' for cross-platform dirs, and 'mac'/'arch'/'ubuntu' for OS-specific dirs.",
+            "description": "directories to be recursively made, organized by OS type. Use 'all' for cross-platform dirs, and 'mac'/'arch'/'ubuntu'/'windows' for OS-specific dirs.",
             "type": "object",
             "properties": {
                 "all": {"type": "array", "items": {"$ref": "#/definitions/dir"}},
                 "mac": {"type": "array", "items": {"$ref": "#/definitions/dir"}},
                 "arch": {"type": "array", "items": {"$ref": "#/definitions/dir"}},
                 "ubuntu": {"type": "array", "items": {"$ref": "#/definitions/dir"}},
+                "windows": {"type": "array", "items": {"$ref": "#/definitions/dir"}},
             },
         },
         "links": {
-            "description": "softlinked dotfiles from ~/dotfiles, organized by OS type. Use 'all' for cross-platform links, and 'mac'/'arch'/'ubuntu' for OS-specific links. For work/private specific links, put them in the respective bootstrap_config_work.json or bootstrap_config_private.json files under links.all.",
+            "description": "softlinked dotfiles from ~/dotfiles, organized by OS type. Use 'all' for cross-platform links, and 'mac'/'arch'/'ubuntu'/'windows' for OS-specific links. For work/private specific links, put them in the respective bootstrap_config_work.json or bootstrap_config_private.json files under links.all.",
             "type": "object",
             "properties": {
                 "all": {"type": "array", "items": {"$ref": "#/definitions/link"}},
                 "mac": {"type": "array", "items": {"$ref": "#/definitions/link"}},
                 "arch": {"type": "array", "items": {"$ref": "#/definitions/link"}},
                 "ubuntu": {"type": "array", "items": {"$ref": "#/definitions/link"}},
+                "windows": {"type": "array", "items": {"$ref": "#/definitions/link"}},
             },
         },
         "commands": {
@@ -49,6 +51,10 @@ schema = {
                     "type": "array",
                     "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
                 },
+                "windows": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
             },
         },
         "packages": {
@@ -58,6 +64,7 @@ schema = {
                 "mac": {"type": "object"},
                 "arch": {"type": "object"},
                 "ubuntu": {"type": "object"},
+                "windows": {"type": "object"},
                 "all": {"type": "object"},
             },
         },
@@ -68,7 +75,19 @@ schema = {
                 "mac": {"type": "object"},
                 "arch": {"type": "object"},
                 "ubuntu": {"type": "object"},
+                "windows": {"type": "object"},
             },
+        },
+        "file_associations": {
+            "description": "Register file extension associations. Currently Windows-only — writes per-user keys under HKCU\\Software\\Classes so Explorer double-click opens the right app. No admin needed.",
+            "type": "object",
+            "properties": {
+                "windows": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/file_assoc"},
+                },
+            },
+            "additionalProperties": False,
         },
     },
     "definitions": {
@@ -109,6 +128,25 @@ schema = {
                 "cmd": {"type": "string", "description": "The command to run."},
                 "check": {"type": "string", "description": "Shell command — if exit 0, skip cmd."},
                 "label": {"type": "string", "description": "Human-readable name for logs (defaults to truncated cmd)."},
+            },
+            "additionalProperties": False,
+        },
+        "file_assoc": {
+            "type": "object",
+            "required": ["ext", "progid", "cmd"],
+            "properties": {
+                "ext": {"type": "string", "description": "Extension including the dot, e.g. '.yaml'"},
+                "progid": {"type": "string", "description": "Class identifier, e.g. 'Neovim.YAML'"},
+                "cmd": {"type": "string", "description": "Launch command — Windows substitutes %1 with the file path"},
+                "name": {
+                    "type": "string",
+                    "description": "Friendly app name shown in the 'Open with' picker (otherwise Windows reads metadata from the first .exe in `cmd`, which is often blank or labeled 'Shim')",
+                },
+                "icon": {
+                    "type": "string",
+                    "description": "Icon for files of this type in Explorer. Format: '<path>,<index>' to pull a PE resource (e.g. 'C:\\\\Program Files\\\\Neovim\\\\bin\\\\nvim.exe,0'), or a path to a .ico file.",
+                },
+                "label": {"type": "string", "description": "Human-readable label for logs"},
             },
             "additionalProperties": False,
         },

--- a/bootstrap/utils.py
+++ b/bootstrap/utils.py
@@ -1,27 +1,39 @@
-"""
-install everything
-"""
+"""install everything"""
 
 import os
 import shutil
 import subprocess
 import sys
 
-from bootstrap import log
+from bootstrap import log, windows
 
-HOMEDIR = os.environ.get("HOME")
-SHELLPATH = os.environ.get("SHELL")
+HOMEDIR = os.path.expanduser("~")
+SHELLPATH = os.environ.get("SHELL")  # None on Windows; subprocess defaults to %COMSPEC% (cmd.exe)
 
-# Package installation order by OS - some types must run before others
-# (e.g., ppa before apt to add repos, brew_tap before brew)
-# Cross-platform types (npm, go_install, etc.) MUST come after OS-specific ones
-# because they depend on tools installed by OS package managers (e.g., npm from nodejs)
-CROSS_PLATFORM_PACKAGE_ORDER = ["npm", "go_install", "cargo", "fisher"]
-OS_SPECIFIC_PACKAGE_ORDER = ["brew_tap", "brew", "brew_cask", "pacman", "yay", "ppa", "apt", "snap"]
+
+# Package installation order by OS — some types must run before others (e.g. ppa before apt to add
+# repos, brew_tap before brew). Cross-platform types (npm, go_install, etc.) MUST come after the
+# OS-specific ones because they depend on tools installed by the OS package managers (e.g. npm
+# comes from nodejs, go_install needs a Go toolchain).
+CROSS_PLATFORM_PACKAGE_ORDER = ["pip", "npm", "go_install", "cargo", "fisher"]
+OS_SPECIFIC_PACKAGE_ORDER = [
+    "brew_tap",
+    "brew",
+    "brew_cask",
+    "pacman",
+    "yay",
+    "ppa",
+    "apt",
+    "snap",
+    "winget",
+    "scoop_bucket",
+    "scoop",
+]
 PACKAGE_ORDER = {
     "mac": ["brew_tap", "brew", "brew_cask"] + CROSS_PLATFORM_PACKAGE_ORDER,
     "arch": ["pacman", "yay"] + CROSS_PLATFORM_PACKAGE_ORDER,
     "ubuntu": ["ppa", "apt", "snap"] + CROSS_PLATFORM_PACKAGE_ORDER,
+    "windows": ["winget", "scoop_bucket", "scoop"] + CROSS_PLATFORM_PACKAGE_ORDER,
     "all": CROSS_PLATFORM_PACKAGE_ORDER,
 }
 # OS-specific package types first, then cross-platform (ensures npm/go are installed before used)
@@ -69,33 +81,53 @@ def _run_cmd(args, cwd=None, shortcircuit=True):
             log.error("Aborting due to short circuit flag, and a failure!")
             sys.exit(1)
 
+    windows.refresh_path()
+
 
 def _mkdirrec(dest, delete_first=False, sudo=False):
-    """recurisvely make a directory"""
+    """recursively make a directory (cross-platform via os.makedirs)"""
     dest = _replace_home(dest)
     if delete_first and os.path.isdir(dest):
         log.action("Remove flag is ON, and destination exists, deleting!")
-        shutil.rmtree(dest)
-    prefix = "sudo " if sudo else ""
-    _run_cmd(prefix + "mkdir -p  " + dest)
+        if sudo:
+            _run_cmd("sudo rm -rf " + dest)
+        else:
+            shutil.rmtree(dest)
+    if sudo:
+        # sudo paths still shell out — they're rare and platform-specific (linux only)
+        _run_cmd("sudo mkdir -p " + dest)
+    else:
+        log.action(f"mkdir -p {dest}")
+        os.makedirs(dest, exist_ok=True)
     assert os.path.isdir(dest)
 
 
 def _softlink(src, dest, cwd=None, sudo=False):
-    """remove dest, then softline src to dest"""
+    """remove dest if present, then symlink src -> dest (cross-platform via os.symlink)
+
+    On Windows, requires Developer Mode to be enabled (or running as admin) so that
+    os.symlink succeeds without SeCreateSymbolicLinkPrivilege.
+    """
     src = _replace_home(src)
     dest = _replace_home(dest)
     log.action(f"linking {src} to {dest}")
-    prefix = "sudo " if sudo else ""
-    _run_cmd(prefix + "ln -f -n -s " + src + " " + dest, cwd)
-    assert os.path.exists(dest)
 
+    if sudo:
+        # sudo path: shell out (rare, linux-only for system paths like /usr/share/...)
+        _run_cmd("sudo ln -f -n -s " + src + " " + dest, cwd)
+        assert os.path.exists(dest)
+        return
 
-def _gitclone(repo, dest):
-    """clone a git repo"""
-    dest = _replace_home(dest)
-    _run_cmd("git clone " + repo + " " + dest)
-    assert os.path.isdir(dest)
+    # Remove existing dest (file, dir-symlink, or broken symlink)
+    if os.path.lexists(dest):
+        if os.path.isdir(dest) and not os.path.islink(dest):
+            # Real directory at dest — refuse to clobber, mirrors `ln -n` behavior
+            raise RuntimeError(f"Refusing to replace real directory at {dest}")
+        os.unlink(dest)
+
+    # target_is_directory matters on Windows (file-symlink vs dir-symlink are different there)
+    os.symlink(src, dest, target_is_directory=os.path.isdir(src))
+    assert os.path.exists(dest) or os.path.islink(dest)
 
 
 # These take the config and execute a series of installs:
@@ -121,6 +153,7 @@ def softlinks(config, section):
 
 def _run_check(check_cmd):
     """Run a precheck command. Returns True if check passes (exit 0)."""
+    windows.refresh_path()
     try:
         result = subprocess.run(
             check_cmd,
@@ -191,11 +224,31 @@ def _install_packages(inner, label):
                 # some snaps need --classic, specify as "package --classic" in config
                 for pkg in inner["snap"]:
                     _run_cmd(f"sudo snap install {pkg}", shortcircuit=False)
-            # note, these could be in "all" or package specific
+            case "winget":
+                windows.install_winget_packages(inner["winget"], _run_cmd)
+            case "scoop_bucket":
+                for bucket in inner["scoop_bucket"]:
+                    _run_cmd(f"scoop bucket add {bucket}", shortcircuit=False)
+            case "scoop":
+                # one at a time so a single missing manifest or transient failure doesn't take
+                # out the rest of the batch — `scoop install P1 P2 P3` stops at the first error
+                for pkg in inner["scoop"]:
+                    _run_cmd(f"scoop install {pkg}", shortcircuit=False)
+            # the package types below can appear in "all" or in any OS-specific section
             case "fisher":
                 _run_cmd("fisher install " + " ".join(inner["fisher"]))
             case "npm":
-                _run_cmd("sudo npm install {0} -g".format(" ".join(inner["npm"])))
+                # Windows npm has no sudo and doesn't need it; POSIX requires sudo for -g installs
+                prefix = "" if sys.platform == "win32" else "sudo "
+                _run_cmd("{0}npm install {1} -g".format(prefix, " ".join(inner["npm"])))
+            case "pip":
+                # Windows: winget Python is a per-user install at %LOCALAPPDATA%\Programs\Python\PythonXX\
+                # whose Scripts dir is already on PATH; plain `pip install` writes there. We deliberately
+                # AVOID --user on Windows because that puts scripts under %APPDATA%\Python\PythonXX\Scripts
+                # which is NOT on PATH by default, making tools "installed but invisible".
+                # POSIX: --user is needed for system Pythons (PEP 668 / apt protection).
+                cmd = "python -m pip install" if sys.platform == "win32" else "python3 -m pip install --user"
+                _run_cmd("{0} {1}".format(cmd, " ".join(inner["pip"])), shortcircuit=False)
             case "go_install":
                 for pkg in inner["go_install"]:
                     _run_cmd(f"go install {pkg}")

--- a/bootstrap/windows.py
+++ b/bootstrap/windows.py
@@ -1,0 +1,170 @@
+"""Windows-specific helpers: registry PATH refresh, winget install with precheck, and
+per-user file association registration. Kept in a separate module so utils.py stays
+focused on cross-platform plumbing — none of this runs on POSIX (refresh_path is a
+no-op there; the file-assoc / winget entry points are gated on sys.platform by callers
+or by the runner script setting --systype windows).
+"""
+
+import os
+import subprocess
+import sys
+
+from bootstrap import log
+
+HOMEDIR = os.path.expanduser("~")
+
+
+def _replace_home(path):
+    return path.replace("~", HOMEDIR)
+
+
+def refresh_path():
+    """Re-read PATH from HKLM and HKCU registry hives into os.environ. No-op off Windows.
+
+    Why this exists: scoop, winget, rustup, the Go installer, and friends all modify
+    HKCU\\Environment\\Path during install. Without this, anything that changes PATH
+    mid-run is invisible to subsequent subprocesses we spawn — os.environ was captured
+    at process startup. We call this both at the end of every _run_cmd (so a freshly
+    installed tool is visible to the next command) and at the start of every _run_check
+    (so a chain of skipped prechecks doesn't keep checking against a stale PATH that
+    our parent shell handed us before any of those tools were installed).
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import winreg
+
+        parts = []
+        for hive, subkey in (
+            (winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"),
+            (winreg.HKEY_CURRENT_USER, "Environment"),
+        ):
+            try:
+                with winreg.OpenKey(hive, subkey) as key:
+                    val, _ = winreg.QueryValueEx(key, "Path")
+                    if val:
+                        parts.append(os.path.expandvars(val))
+            except OSError:
+                pass
+        if parts:
+            os.environ["PATH"] = os.pathsep.join(parts)
+    except Exception:
+        pass  # PATH refresh is best-effort; never fail the run if registry access errors
+
+
+def install_winget_packages(pkgs, run_cmd):
+    """Install each winget package one at a time, skipping any already installed.
+
+    winget exits non-zero (e.g. 0x8a15002b "no available upgrade") when a package is
+    already installed at the latest version, which the engine would otherwise log as a
+    failure even though nothing went wrong. `winget list --id X -e` exits 0 iff the
+    package is installed regardless of upgrade availability — exactly the signal we want
+    for an idempotent skip. We also install one at a time so a single missing manifest
+    or transient network failure doesn't take out the rest of the batch.
+    """
+    for pkg in pkgs:
+        check = subprocess.run(
+            f"winget list --id {pkg} -e --accept-source-agreements",
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+        )
+        if check.returncode == 0:
+            log.skip(f"winget: {pkg} already installed")
+            continue
+        run_cmd(
+            f"winget install --id {pkg} --silent --accept-source-agreements --accept-package-agreements",
+            shortcircuit=False,
+        )
+
+
+def set_file_assoc(ext, progid, cmd, name=None, icon=None, label=None):
+    """Register a per-user file association under HKCU\\Software\\Classes — no admin needed.
+
+    Writes:
+      HKCU\\Software\\Classes\\<ext>\\(default)                          = <progid>
+      HKCU\\Software\\Classes\\<progid>\\(default)                       = <name>           (if name)
+      HKCU\\Software\\Classes\\<progid>\\DefaultIcon\\(default)          = <icon>           (if icon)
+      HKCU\\Software\\Classes\\<progid>\\shell\\open\\FriendlyAppName    = <name>           (if name)
+      HKCU\\Software\\Classes\\<progid>\\shell\\open\\command\\(default) = <cmd>
+
+    The `name` writes are what make the "Open with" picker show e.g. "Neovim" instead
+    of "Terminal" or "Shim". Windows reads FriendlyAppName / the ProgID default before
+    falling back to the launcher .exe's embedded ProductName, which on stripped binaries
+    or AppX execution aliases is often blank or generic.
+
+    The `icon` write sets the Explorer thumbnail. Format is either "<path>,<index>" to
+    pull a PE icon resource (e.g. "C:\\Program Files\\Neovim\\bin\\nvim.exe,0") or a path
+    to a .ico file. Without it, files of the type inherit the icon of whatever wrapper
+    exe Windows finds first in cmd, which is often a generic shell-script icon when the
+    launcher is `wt` / `cmd` / `pwsh`.
+
+    For extensions Windows already claims via UserChoice (e.g. .txt → Notepad on Win11),
+    we clear UserChoice so Explorer falls back to our class registration. Windows blocks
+    programmatic *creation* of UserChoice (it's hash-protected) but allows deletion. We
+    only delete UserChoice when it points to a *different* ProgID — a user's "Always use
+    this app" selection that already matches us is preserved across re-runs.
+    """
+    import winreg
+
+    label = label or f"{ext} -> {progid}"
+    log.action(f"file association: {label}")
+
+    cmd = _replace_home(cmd)
+    if icon:
+        icon = _replace_home(icon)
+
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"Software\Classes\{ext}") as k:
+        winreg.SetValueEx(k, None, 0, winreg.REG_SZ, progid)
+
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"Software\Classes\{progid}") as k:
+        if name:
+            winreg.SetValueEx(k, None, 0, winreg.REG_SZ, name)
+
+    if icon:
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"Software\Classes\{progid}\DefaultIcon") as k:
+            winreg.SetValueEx(k, None, 0, winreg.REG_SZ, icon)
+
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"Software\Classes\{progid}\shell\open") as k:
+        if name:
+            winreg.SetValueEx(k, "FriendlyAppName", 0, winreg.REG_SZ, name)
+
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"Software\Classes\{progid}\shell\open\command") as k:
+        winreg.SetValueEx(k, None, 0, winreg.REG_SZ, cmd)
+
+    uc_path = rf"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\{ext}\UserChoice"
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, uc_path) as k:
+            current_progid, _ = winreg.QueryValueEx(k, "ProgId")
+    except (FileNotFoundError, OSError):
+        current_progid = None
+    if current_progid is not None and current_progid != progid:
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, uc_path)
+        except (FileNotFoundError, OSError):
+            pass
+
+
+def install_file_associations(config):
+    """Top-level entry: reads config['file_associations']['windows'] and registers each."""
+    if "file_associations" not in config:
+        log.skip("No file_associations in config")
+        return
+    section = config["file_associations"].get("windows", [])
+    if not section:
+        log.skip("No windows entries in file_associations")
+        return
+    if sys.platform != "win32":
+        log.skip("file_associations.windows: not on Windows, skipping")
+        return
+    log.header("Registering Windows file associations")
+    for assoc in section:
+        set_file_assoc(
+            assoc["ext"],
+            assoc["progid"],
+            assoc["cmd"],
+            name=assoc.get("name"),
+            icon=assoc.get("icon"),
+            label=assoc.get("label"),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bootstrap"
-version = "1.2.1"
+version = "1.3.0"
 description = "Automatic setup of new machines"
 authors = ["Tommy Carpenter <tommyjcarpenter@gmail.com>"]
 license = "MIT"

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,6 +1,7 @@
 {
     "comments": [
         "Comments live here since JSON has no native commenting mechanism.",
+        "All sections except `comments` are processed by the engine.",
         "Use bootstrap_config_work.json / bootstrap_config_private.json for env-specific overlays."
     ],
     "initial_mkdirs": {
@@ -15,6 +16,9 @@
         ],
         "ubuntu": [
             { "dir": "~/.config/kitty" }
+        ],
+        "windows": [
+            { "dir": "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState" }
         ]
     },
     "links": {
@@ -22,7 +26,8 @@
             { "src": "~/dotfiles/init.lua",        "dst": "~/.config/nvim/init.lua" },
             { "src": "~/dotfiles/tmux.conf",       "dst": "~/.tmux.conf" },
             { "src": "~/dotfiles/yamllint-config", "dst": "~/.config/yamllint/config" },
-            { "src": "~/dotfiles/gitconfig",       "dst": "~/.gitconfig" }
+            { "src": "~/dotfiles/gitconfig",       "dst": "~/.gitconfig" },
+            { "src": "~/dotfiles/starship.toml",   "dst": "~/.config/starship.toml" }
         ],
         "mac": [],
         "arch": [
@@ -30,6 +35,10 @@
         ],
         "ubuntu": [
             { "src": "~/dotfiles/kitty.conf", "dst": "~/.config/kitty/kitty.conf" }
+        ],
+        "windows": [
+            { "src": "~/dotfiles/windows-terminal-settings.json",
+              "dst": "~/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json" }
         ]
     },
     "commands": {
@@ -48,6 +57,23 @@
                 "cmd": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
                 "check": "rustc --version",
                 "label": "Install Rust toolchain"
+            }
+        ],
+        "windows": [
+            {
+                "cmd": "pwsh -NoProfile -Command \"Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force; iwr -useb get.scoop.sh | iex\"",
+                "check": "scoop --version",
+                "label": "Install scoop"
+            },
+            {
+                "cmd": "winget install --id Rustlang.Rustup -e --silent --accept-source-agreements --accept-package-agreements",
+                "check": "rustup --version",
+                "label": "Install Rustup"
+            },
+            {
+                "cmd": "rustup default stable",
+                "check": "rustup show active-toolchain",
+                "label": "Install + select stable Rust toolchain"
             }
         ]
     },
@@ -73,6 +99,9 @@
                 "eza",
                 "fzf",
                 "jq",
+                "stylua",
+                "ruff",
+                "black",
                 "pyright",
                 "yaml-language-server",
                 "bash-language-server",
@@ -81,13 +110,50 @@
         },
         "arch": {
             "pacman": ["nodejs", "tmux", "eza", "kitty"],
-            "yay": ["jq"]
+            "yay": ["jq", "ruff", "stylua"]
         },
         "ubuntu": {
             "apt": ["neovim", "ripgrep", "tmux", "fzf", "jq"],
             "npm": ["pyright", "yaml-language-server", "bash-language-server"],
             "go_install": ["golang.org/x/tools/gopls@latest"],
             "cargo": ["stylua"]
+        },
+        "windows": {
+            "winget": [
+                "Neovim.Neovim",
+                "Git.Git",
+                "Starship.Starship",
+                "Microsoft.WindowsTerminal",
+                "OpenJS.NodeJS.LTS"
+            ],
+            "scoop_bucket": ["main", "nerd-fonts"],
+            "scoop": [
+                "eza", "bat", "fzf", "ripgrep", "jq", "fd", "zoxide",
+                "delta", "ruff", "shfmt", "stylua", "zig",
+                "VictorMono-NF-Mono"
+            ],
+            "pip": ["black", "isort"],
+            "npm": ["pyright", "yaml-language-server", "bash-language-server", "vscode-langservers-extracted"]
         }
+    },
+    "file_associations": {
+        "windows": [
+            {
+                "ext": ".yaml",
+                "progid": "Neovim.YAML",
+                "cmd": "wt -- nvim \"%1\"",
+                "name": "Neovim",
+                "icon": "~/dotfiles/icons/neovim.ico",
+                "label": "open .yaml in Neovim (via Windows Terminal)"
+            },
+            {
+                "ext": ".txt",
+                "progid": "Neovim.TXT",
+                "cmd": "wt -- nvim \"%1\"",
+                "name": "Neovim",
+                "icon": "~/dotfiles/icons/neovim.ico",
+                "label": "open .txt in Neovim (via Windows Terminal)"
+            }
+        ]
     }
 }


### PR DESCRIPTION
  - winget, scoop, scoop_bucket package types
  - pip package type (cross-platform)
  - file_associations: per-user HKCU file extension → app launcher (Windows)
  - npm on Windows skips sudo
  - cross-platform os.makedirs / os.symlink (drops bash dep)
  - breaking: --systype always auto-detected from sys.platform
  - Windows helpers extracted to bootstrap/windows.py

