### PR TITLE
softlink: friendly error on WinError 1314 (no symlink privilege)

### DIFF
--- a/bootstrap/utils.py
+++ b/bootstrap/utils.py
@@ -127,7 +127,17 @@ def _softlink(src, dest, cwd=None, sudo=False):
         os.unlink(dest)
 
     # target_is_directory matters on Windows (file-symlink vs dir-symlink are different there)
-    os.symlink(src, dest, target_is_directory=os.path.isdir(src))
+    try:
+        os.symlink(src, dest, target_is_directory=os.path.isdir(src))
+    except OSError as e:
+        if sys.platform == "win32" and getattr(e, "winerror", None) == 1314:
+            raise RuntimeError(
+                f"Cannot create symlink {dest} -> {src}: "
+                "this Windows account lacks SeCreateSymbolicLinkPrivilege. "
+                "Enable Developer Mode (Settings -> System -> For developers -> Developer Mode) "
+                "or re-run bootstrap from an elevated (admin) shell."
+            ) from e
+        raise
     assert os.path.exists(dest) or os.path.islink(dest)
 
 


### PR DESCRIPTION
Catch \`OSError\` with \`winerror == 1314\` in \`_softlink\` and re-raise as a \`RuntimeError\` that tells the user how to fix it (enable Developer Mode, or run elevated).  Without this, a fresh Windows machine without Developer Mode gets a raw stack trace from the bottom of \`utils.py\` and no hint what's wrong