### PR TITLE
add post_commands: runs after packages + file_associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Note: For Ubuntu, `ppa` entries are automatically processed before `apt` regardl
 
 6. `prereq_packages`: packages that provide language toolchains (rust/cargo, go, poetry) needed before other packages can be installed. These are installed before `packages`. Structure is the same as `packages` but keyed by OS only (no `all` section).
 7. `file_associations` (Windows-only): per-user Windows file extension → app launcher. Each entry has `ext` (`.yaml`), `progid` (`Neovim.YAML`), and `cmd` (`wt -- nvim "%1"`). Writes `HKCU\Software\Classes` so no admin is needed; also clears `UserChoice` so Explorer double-click respects your mapping. Runs after `packages` so the target apps exist.
+8. `post_commands`: same shape as `commands`, but runs *after* packages and `file_associations`. Use this for steps that depend on packages already being installed — e.g. registering a font file that scoop installed but didn't put in the user font registry.
 
 ## Environment-Specific Configs
 

--- a/bootstrap/boot.py
+++ b/bootstrap/boot.py
@@ -17,6 +17,8 @@ def boot_config(cfg: dict, systype, loctype, run_prereqs=False):
      8. system specific packages (installs npm, go, etc via pacman/brew/apt/winget)
      9. generic packages (uses pip, npm, go_install, cargo, fisher)
     10. file associations (windows-only, runs after packages so target apps exist)
+    11. post_commands — runs after everything else, for steps that depend on
+        installed packages (e.g. registering Windows fonts that scoop installed)
     """
     mkdirs(cfg, "all")
     mkdirs(cfg, systype)
@@ -31,6 +33,8 @@ def boot_config(cfg: dict, systype, loctype, run_prereqs=False):
     packages(cfg, systype)
     packages(cfg, "all")
     install_file_associations(cfg)
+    cmds(cfg, "all", section_key="post_commands")
+    cmds(cfg, systype, section_key="post_commands")
 
 
 def boot(cfg: dict, name, systype, loctype, extra_cfg: dict = None):

--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -32,30 +32,12 @@ schema = {
             },
         },
         "commands": {
-            "description": "a list of arbitrary commands to run, which can be specified as os-agnostic, or by OS type. Warning, whatever you put here will be executed!. Each entry can be a plain string or an object with cmd, check, and label fields.",
-            "type": "object",
-            "properties": {
-                "all": {
-                    "type": "array",
-                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
-                },
-                "mac": {
-                    "type": "array",
-                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
-                },
-                "arch": {
-                    "type": "array",
-                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
-                },
-                "ubuntu": {
-                    "type": "array",
-                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
-                },
-                "windows": {
-                    "type": "array",
-                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
-                },
-            },
+            "description": "a list of arbitrary commands to run, which can be specified as os-agnostic, or by OS type. Warning, whatever you put here will be executed!. Each entry can be a plain string or an object with cmd, check, and label fields. Runs *before* packages — use it for things package install depends on (e.g. installing scoop).",
+            "$ref": "#/definitions/commands_section",
+        },
+        "post_commands": {
+            "description": "Same shape as `commands`, but runs *after* packages and file_associations. Use this for steps that depend on packages already being installed — e.g. registering a font file that scoop installed but didn't put in the user font registry.",
+            "$ref": "#/definitions/commands_section",
         },
         "packages": {
             "description": "a list of packages to install, which can be specified as os-agnostic, or by OS type. Examples of agnostic installs include `npm`. Examples of `mac` include `brew`. You can also include 'agnostic' installs in the os-specific sections, for example, 'I only want this NPM package installed on my mac'.",
@@ -132,6 +114,31 @@ schema = {
                 "label": {"type": "string", "description": "Human-readable name for logs (defaults to truncated cmd)."},
             },
             "additionalProperties": False,
+        },
+        "commands_section": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
+                "mac": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
+                "arch": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
+                "ubuntu": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
+                "windows": {
+                    "type": "array",
+                    "items": {"oneOf": [{"type": "string"}, {"$ref": "#/definitions/command_with_check"}]},
+                },
+            },
         },
         "package_list": {
             "type": "array",

--- a/bootstrap/utils.py
+++ b/bootstrap/utils.py
@@ -179,13 +179,15 @@ def _run_check(check_cmd):
         return False
 
 
-def cmds(config, systype):
-    """run all commands"""
-    if "commands" not in config:
-        log.skip("No commands in config")
+def cmds(config, systype, section_key="commands"):
+    """run all commands from config[section_key][systype]. section_key is 'commands'
+    for the pre-package step (default) and 'post_commands' for the post-package step.
+    Same shape on both — list of strings or {cmd, check, label} dicts."""
+    if section_key not in config:
+        log.skip(f"No {section_key} in config")
         return
-    if systype in config["commands"]:
-        for c in config["commands"][systype]:
+    if systype in config[section_key]:
+        for c in config[section_key][systype]:
             if isinstance(c, str):
                 _run_cmd(c)
             else:


### PR DESCRIPTION
## Summary
- New top-level config section \`post_commands\` (same shape as \`commands\`) that runs at the end of the bootstrap flow instead of the start
- Schema: factor the per-OS commands shape into a reusable \`commands_section\` definition; \`commands\` and \`post_commands\` both reference it
- \`utils.cmds\` takes a new \`section_key\` arg (defaults to \`\"commands\"\`) so the same plumbing handles both phases

## Why
The motivating case is a step that depends on a package already being installed — e.g. registering a font file that scoop dropped on disk but didn't put in the user font registry. Without \`post_commands\` you'd have to either bundle install + post-install into one giant cmd (multi-line PowerShell quoted into JSON, pretty miserable to maintain) or split the work across two bootstrap runs.

Order is now:
\`\`\`
mkdirs → links → commands → prereq_packages → packages →
file_associations → post_commands
\`\`\`

## Test plan
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`sample_config.json\` validates against the new schema
- [ ] Manual: dotfiles consumes \`post_commands\` for the VictorMono NFM font registration (separate dotfiles change, not in this PR)