### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Summary
 This "package" allows you to specify a complete dev env setup, including packages to install (homebrew, yay, pacman, winget, scoop, npm, etc etc).
-You write a `config.json`, then run a python CLI tool.
+You write a `bootstrap_config.json`, then run a python CLI tool.
 I use this to keep multiple machines (work mac, home Arch, Docker based arch dev boxes, Windows boxes) all up to date with my dev environment.
 
 # Isn't there stuff already like this?
@@ -8,33 +8,29 @@ There are probably many. However, the well known ones; Puppet, Chef, Ansible, et
 
 There are a lot of "dotfiles" repos on github; this depends on that --- it requires you to have a `~/dotfiles/` repo that can be symlinked against, but it goes a lot further (than dotfiles).
 
-This was only a few hundred lines of python, and I've been using this to setup new computers (eg new Macs, new PC builds) and Dockerized development environments for years.
-
-I am planning on making this more extensible so the user can provide functions that get run.
-
 # Prerequisites
-1. python3 (I am using 3.11) and `poetry`
+1. python3 (3.10+ required; I am using 3.11) and `poetry`
 2. if on mac, `homebrew`; if on Arch, `yay`; if on Windows, `winget` (ships with Windows 11) and/or `scoop`
 3. If on mac, XCode command line tools (can't even build `gcc` from `homebrew` without this): `sudo xcode-select --install`
 4. If on Windows, enable Developer Mode (Settings → System → For developers → Developer Mode). This lets `os.symlink` work without admin.
 5. make a directory called `dotfiles/` in your home directory with all of your dotfiles. I personally have a private github `dotfiles` repo that I clone there.
-6. Write `config.json`; see the next section
+6. Write `~/dotfiles/bootstrap_config.json`; see the next section
 
-# Config.json
-To use this package, you write a `config.json` to describe what you would like linked, installed, ran, etc.
+# Config
+To use this package, you write a `bootstrap_config.json` in your `~/dotfiles/` directory to describe what you would like linked, installed, ran, etc.
 That is the only input, other than a few cmd line parameters.
 
-A sample (actually a copy of my real one!) config is included; see `sample_config.json`
+A sample config is included in this repo; see `sample_config.json`.
 
-My personal `config.json` is in my private `dotfiles` repo, and I clone it in step 4 above.
+My personal `bootstrap_config.json` lives in my private `dotfiles` repo, which I clone into `~/dotfiles/` (see Prerequisites).
 
-Please see the (evolving) jsonschema for `config.json` in `bootstrap/schema.py` for the full schema.
+Please see the (evolving) jsonschema for the config in `bootstrap/schema.py` for the full schema.
 These are the major sections:
 
 1. `comments`: this is a list of strings for your own sanity, since JSON has no native commenting mechanism.
-2. `initial_mkdirs`: directories to be recursively made. For example, `~/.ssh/..`. You can specify whether to try deleting the directory first, which is helpful for "rebootstrapping"
-3. `links`: this is a list of softlinked dotfiles, from you `~/dotfiles` directory, that can vary by "location" if you want. IE, if you have a `.gitconfig` that you use on "work" machines, and a seperate one you use on "private" machines, you can specify these seperately, and when you run the script, you specify the location. There is also a generic `all` key for specifying location-agnostic keys.
-4. `commands`: a list of arbitrary commands to run, which can be specified as os-agnostic, or by OS type. Warning, whatever you put here will be executed! If the command needs sudo, it will pause and ask for your sudo password using a `STDIN` pipe, so privileged commands are fine.
+2. `initial_mkdirs`: directories to be recursively made, grouped by OS (`all` plus `mac`/`arch`/`ubuntu`/`windows`). For example, `~/.ssh/..`. Per entry you can set `delfirst` to try deleting the directory first (helpful for "rebootstrapping"), and `sudo` to make it with sudo (for system directories outside `~`).
+3. `links`: softlinked dotfiles from your `~/dotfiles` directory, grouped by OS — an `all` key for cross-platform links plus `mac`/`arch`/`ubuntu`/`windows` for OS-specific ones. Each entry has `src`, `dst`, and an optional `sudo` (for system paths outside `~`). To vary a link by location (e.g. a different `.gitconfig` on work vs private machines), put it in the per-location config files described under "Environment-Specific Configs" below.
+4. `commands`: a list of arbitrary commands to run *before* packages are installed (use it for things package install depends on, like installing `scoop`). Can be specified as os-agnostic (`all`) or by OS type. Warning, whatever you put here will be executed! Each entry is either a plain string, or an object with `cmd` (the command to run), an optional `check` (a shell command; if it exits 0, `cmd` is skipped, making the step idempotent), and an optional `label` (human-readable name for logs). If a command needs sudo, it will prompt for your password on the terminal, so privileged commands are fine.
 5. `packages`: a list of packages to install, which can be specified as os-agnostic, or by OS type. You can also include "agnostic" installs in the os-specific sections, for example, "I only want this NPM package installed on my mac".
 
 Supported package managers:
@@ -51,7 +47,7 @@ Supported package managers:
 Note: For Ubuntu, `ppa` entries are automatically processed before `apt` regardless of order in the config. Similarly on Windows, `scoop_bucket` is processed before `scoop` so buckets are available when packages install.
 
 6. `prereq_packages`: packages that provide language toolchains (rust/cargo, go, poetry) needed before other packages can be installed. These are installed before `packages`. Structure is the same as `packages` but keyed by OS only (no `all` section).
-7. `file_associations` (Windows-only): per-user Windows file extension → app launcher. Each entry has `ext` (`.yaml`), `progid` (`Neovim.YAML`), and `cmd` (`wt -- nvim "%1"`). Writes `HKCU\Software\Classes` so no admin is needed; also clears `UserChoice` so Explorer double-click respects your mapping. Runs after `packages` so the target apps exist.
+7. `file_associations` (Windows-only): per-user Windows file extension → app launcher. Each entry has required `ext` (`.yaml`), `progid` (`Neovim.YAML`), and `cmd` (`wt -- nvim "%1"`), plus optional `name` (friendly app name shown in the "Open with" picker), `icon` (Explorer icon — a `.ico` path or `<path>,<index>` to pull a PE resource), and `label` (human-readable name for logs). Writes `HKCU\Software\Classes` so no admin is needed; it also clears `UserChoice` (only when it points at a different app) so Explorer double-click respects your mapping. Runs after `packages` so the target apps exist.
 8. `post_commands`: same shape as `commands`, but runs *after* packages and `file_associations`. Use this for steps that depend on packages already being installed — e.g. registering a font file that scoop installed but didn't put in the user font registry.
 
 ## Environment-Specific Configs
@@ -63,21 +59,13 @@ You can create separate config files for work vs private environments:
 
 The extra config files are optional and use the same schema. They're processed after the main config, so you can put environment-specific packages (like kubernetes tools for work) in separate files.
 
-# Prerequisites
-
-1. You must have `homebrew` installed on mac, `yay` installed on Arch linux, and `winget`/`scoop` on Windows.
-2. On Windows: enable Developer Mode (Settings → System → For developers) so symlinks work without admin.
-3. You must have `~/dotfiles/` directory with your dotfiles in it.
-4. You must have `config.json` file written.
-5. You must have `python3` and `poetry` installed.
-
 # Install and Running
 
     poetry install
     poetry run runboot --loctype work     # work machines
     poetry run runboot --loctype private  # personal machines
 
-The systype (mac, arch, ubuntu, windows) is detected from `sys.platform` and `/etc/os-release`. The script is idempotent — safe to run repeatedly. Add packages to `config.json` and re-run.
+The systype (mac, arch, ubuntu, windows) is detected from `sys.platform` and `/etc/os-release`. The script is idempotent — safe to run repeatedly. Add packages to `bootstrap_config.json` and re-run.
 
 # Major TODOs:
 

--- a/bootstrap/os_specific/windows.py
+++ b/bootstrap/os_specific/windows.py
@@ -1,8 +1,8 @@
 """Windows-specific helpers: registry PATH refresh, winget install with precheck, and
 per-user file association registration. Kept in a separate module so utils.py stays
 focused on cross-platform plumbing — none of this runs on POSIX (refresh_path is a
-no-op there; the file-assoc / winget entry points are gated on sys.platform by callers
-or by the runner script setting --systype windows).
+no-op there; the file-assoc / winget entry points are gated on sys.platform by callers,
+and systype is auto-detected as "windows" only on win32).
 """
 
 import os

--- a/bootstrap/runboot.py
+++ b/bootstrap/runboot.py
@@ -28,7 +28,8 @@ def detect_systype():
         except FileNotFoundError:
             pass
     raise RuntimeError(
-        f"Could not auto-detect systype (platform={sys.platform!r}). Please specify --systype explicitly."
+        f"Could not auto-detect systype (platform={sys.platform!r}). "
+        "Only mac, arch, ubuntu, and windows are supported; add support in detect_systype()."
     )
 
 


### PR DESCRIPTION
Bring the README back in line with the code, and remove stale `--systype` references left over from when systype became auto-detected.

The README had drifted from `bootstrap/schema.py` and the boot order in several places: the main config file is actually `bootstrap_config.json` (not `config.json`), `links` are grouped by OS rather than by "location", and `commands`/`file_associations` had gained fields that were never documented. Separately, `--systype` was removed as a flag a while back (systype is now inferred from `sys.platform` and `/etc/os-release`), but an error message and a module docstring still told users to pass it.

Changes:
- **`README.md`**: correct the config filename to `bootstrap_config.json` throughout; regroup `links` by OS and document the per-link / per-dir `sudo` option; document the `commands`/`post_commands` `{cmd, check, label}` object form and that `commands` runs before packages; document the optional `name`/`icon`/`label` fields on `file_associations`; remove the duplicate Prerequisites section and a couple of stale intro paragraphs; note that python 3.10+ is required.
- **`bootstrap/runboot.py`**: the auto-detect failure message no longer references the removed `--systype` flag; it now lists the supported platforms instead.
- **`bootstrap/os_specific/windows.py`**: module docstring updated; systype is auto-detected as "windows" on win32, not set via a flag.