### PR TITLE
add windows HKEY support

### DIFF
--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -74,7 +74,7 @@ schema = {
             "additionalProperties": False,
         },
         "shell_menu_cleanup": {
-            "description": "Windows right-click menu cleanup state, consumed by bootstrap_scripts/cleanup-shell-menu.ps1. Three arrays cover the three places shell verbs hide: com_handlers_blocked writes CLSIDs to the HKLM Shell Extensions Blocked list, static_verbs_disabled writes an empty LegacyDisable REG_SZ under a verb key, appx_packages_removed passes a wildcard pattern to Get-AppxPackage | Remove-AppxPackage for MSIX-packaged shell extensions.",
+            "description": "Windows right-click menu cleanup state. Three arrays cover the three places shell verbs hide: com_handlers_blocked writes CLSIDs to the HKLM Shell Extensions Blocked list, static_verbs_disabled writes an empty LegacyDisable REG_SZ under a verb key, appx_packages_removed passes a wildcard pattern to Get-AppxPackage | Remove-AppxPackage for MSIX-packaged shell extensions.",
             "type": "object",
             "properties": {
                 "windows": {

--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -73,6 +73,31 @@ schema = {
             },
             "additionalProperties": False,
         },
+        "shell_menu_cleanup": {
+            "description": "Windows right-click menu cleanup state, consumed by bootstrap_scripts/cleanup-shell-menu.ps1. Three arrays cover the three places shell verbs hide: com_handlers_blocked writes CLSIDs to the HKLM Shell Extensions Blocked list, static_verbs_disabled writes an empty LegacyDisable REG_SZ under a verb key, appx_packages_removed passes a wildcard pattern to Get-AppxPackage | Remove-AppxPackage for MSIX-packaged shell extensions.",
+            "type": "object",
+            "properties": {
+                "windows": {
+                    "type": "object",
+                    "properties": {
+                        "com_handlers_blocked": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/shell_menu_com_handler"},
+                        },
+                        "static_verbs_disabled": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/shell_menu_static_verb"},
+                        },
+                        "appx_packages_removed": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/shell_menu_appx_package"},
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            },
+            "additionalProperties": False,
+        },
     },
     "definitions": {
         "dir": {
@@ -184,6 +209,33 @@ schema = {
                     "description": "Icon for files of this type in Explorer. Format: '<path>,<index>' to pull a PE resource (e.g. 'C:\\\\Program Files\\\\Neovim\\\\bin\\\\nvim.exe,0'), or a path to a .ico file.",
                 },
                 "label": {"type": "string", "description": "Human-readable label for logs"},
+            },
+            "additionalProperties": False,
+        },
+        "shell_menu_com_handler": {
+            "type": "object",
+            "required": ["clsid"],
+            "properties": {
+                "clsid": {"type": "string", "description": "CLSID like '{3D1975AF-48C6-4f8e-A182-BE0E08FA86A9}'. Written as a value name (empty REG_SZ) under HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Blocked."},
+                "name": {"type": "string", "description": "Human-readable label for logs"},
+            },
+            "additionalProperties": False,
+        },
+        "shell_menu_static_verb": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {"type": "string", "description": "Registry path to the verb key, e.g. 'HKLM:\\\\Software\\\\Classes\\\\Directory\\\\shell\\\\AnyCode'. An empty LegacyDisable REG_SZ is written under the key, hiding the verb from the menu without deleting it. Treated as already-done if the key doesn't exist on the current machine."},
+                "name": {"type": "string", "description": "Human-readable label for logs"},
+            },
+            "additionalProperties": False,
+        },
+        "shell_menu_appx_package": {
+            "type": "object",
+            "required": ["name_pattern"],
+            "properties": {
+                "name_pattern": {"type": "string", "description": "Wildcard package name pattern for Get-AppxPackage, e.g. '*Mp3tag.ShellExtension*'. Matching packages are uninstalled with Remove-AppxPackage."},
+                "name": {"type": "string", "description": "Human-readable label for logs"},
             },
             "additionalProperties": False,
         },

--- a/bootstrap/schema.py
+++ b/bootstrap/schema.py
@@ -216,7 +216,10 @@ schema = {
             "type": "object",
             "required": ["clsid"],
             "properties": {
-                "clsid": {"type": "string", "description": "CLSID like '{3D1975AF-48C6-4f8e-A182-BE0E08FA86A9}'. Written as a value name (empty REG_SZ) under HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Blocked."},
+                "clsid": {
+                    "type": "string",
+                    "description": "CLSID like '{3D1975AF-48C6-4f8e-A182-BE0E08FA86A9}'. Written as a value name (empty REG_SZ) under HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Blocked.",
+                },
                 "name": {"type": "string", "description": "Human-readable label for logs"},
             },
             "additionalProperties": False,
@@ -225,7 +228,10 @@ schema = {
             "type": "object",
             "required": ["path"],
             "properties": {
-                "path": {"type": "string", "description": "Registry path to the verb key, e.g. 'HKLM:\\\\Software\\\\Classes\\\\Directory\\\\shell\\\\AnyCode'. An empty LegacyDisable REG_SZ is written under the key, hiding the verb from the menu without deleting it. Treated as already-done if the key doesn't exist on the current machine."},
+                "path": {
+                    "type": "string",
+                    "description": "Registry path to the verb key, e.g. 'HKLM:\\\\Software\\\\Classes\\\\Directory\\\\shell\\\\AnyCode'. An empty LegacyDisable REG_SZ is written under the key, hiding the verb from the menu without deleting it. Treated as already-done if the key doesn't exist on the current machine.",
+                },
                 "name": {"type": "string", "description": "Human-readable label for logs"},
             },
             "additionalProperties": False,
@@ -234,7 +240,10 @@ schema = {
             "type": "object",
             "required": ["name_pattern"],
             "properties": {
-                "name_pattern": {"type": "string", "description": "Wildcard package name pattern for Get-AppxPackage, e.g. '*Mp3tag.ShellExtension*'. Matching packages are uninstalled with Remove-AppxPackage."},
+                "name_pattern": {
+                    "type": "string",
+                    "description": "Wildcard package name pattern for Get-AppxPackage, e.g. '*Mp3tag.ShellExtension*'. Matching packages are uninstalled with Remove-AppxPackage.",
+                },
                 "name": {"type": "string", "description": "Human-readable label for logs"},
             },
             "additionalProperties": False,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -54,5 +54,53 @@ class TestPackageSchema(unittest.TestCase):
             config_validate({"prereq_packages": {"mac": {"bogus_type": ["x"]}}})
 
 
+class TestShellMenuCleanupSchema(unittest.TestCase):
+    def test_valid_full(self):
+        config_validate(
+            {
+                "shell_menu_cleanup": {
+                    "windows": {
+                        "com_handlers_blocked": [{"clsid": "{3D1975AF-48C6-4f8e-A182-BE0E08FA86A9}", "name": "Foo"}],
+                        "static_verbs_disabled": [
+                            {"path": "HKLM:\\Software\\Classes\\Directory\\shell\\AnyCode", "name": "AnyCode"}
+                        ],
+                        "appx_packages_removed": [{"name_pattern": "*Mp3tag.ShellExtension*", "name": "Mp3tag"}],
+                    }
+                }
+            }
+        )
+
+    def test_valid_minimal_required_only(self):
+        # name is optional everywhere; only the required key per definition is needed
+        config_validate(
+            {
+                "shell_menu_cleanup": {
+                    "windows": {
+                        "com_handlers_blocked": [{"clsid": "{abc}"}],
+                        "static_verbs_disabled": [{"path": "HKLM:\\x"}],
+                        "appx_packages_removed": [{"name_pattern": "*x*"}],
+                    }
+                }
+            }
+        )
+
+    def test_missing_required_clsid_rejected(self):
+        with self.assertRaises(ValidationError):
+            config_validate({"shell_menu_cleanup": {"windows": {"com_handlers_blocked": [{"name": "Foo"}]}}})
+
+    def test_missing_required_path_rejected(self):
+        with self.assertRaises(ValidationError):
+            config_validate({"shell_menu_cleanup": {"windows": {"static_verbs_disabled": [{"name": "Foo"}]}}})
+
+    def test_unknown_property_rejected(self):
+        # typo'd array key under windows is not in properties → additionalProperties False
+        with self.assertRaises(ValidationError):
+            config_validate({"shell_menu_cleanup": {"windows": {"com_handlers_blockd": [{"clsid": "{x}"}]}}})
+
+    def test_unknown_os_section_rejected(self):
+        with self.assertRaises(ValidationError):
+            config_validate({"shell_menu_cleanup": {"linux": {"com_handlers_blocked": [{"clsid": "{x}"}]}}})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a new optional `shell_menu_cleanup` section to the config schema for declaring Windows Explorer right-click (shell) menu cleanup state. Windows-only, like `file_associations`; it captures the three distinct places a shell verb can hide so they can be cleaned up declaratively rather than by hand.

The section nests under a `windows` key and exposes three arrays, one per mechanism:

- `com_handlers_blocked`: CLSIDs written as empty REG_SZ value names under `HKLM\Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Blocked`.
- `static_verbs_disabled`: registry verb keys that get an empty `LegacyDisable` REG_SZ, hiding the verb without deleting the key; treated as already-done when the key is absent on the current machine.
- `appx_packages_removed`: wildcard package-name patterns fed to `Get-AppxPackage | Remove-AppxPackage` for MSIX-packaged shell extensions.

Each entry requires only its identifying field (`clsid` / `path` / `name_pattern`); an optional `name` is carried for log readability. Every level sets `additionalProperties: false`, so a typo'd array key or OS section fails validation rather than being silently skipped, consistent with the rest of the schema.

Changes:
- `bootstrap/schema.py`: new `shell_menu_cleanup` top-level section plus three `definitions` (`shell_menu_com_handler`, `shell_menu_static_verb`, `shell_menu_appx_package`).
- `tests/test_schema.py`: new `TestShellMenuCleanupSchema` with positive cases (full and required-only) and negative cases (missing required field, unknown property, unknown OS section).
